### PR TITLE
feat: Add `TakeMultipleStock` and `AddMultipleStock` resources

### DIFF
--- a/almacen-service-network-resources/build.gradle.kts
+++ b/almacen-service-network-resources/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "1.0.0-SNAPSHOT"
+version = "1.1.0-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/almacen-service-network-resources/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/resources/AlmacenItemResource.kt
+++ b/almacen-service-network-resources/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/resources/AlmacenItemResource.kt
@@ -23,6 +23,30 @@ class AlmacenItemResource {
         fun getRoute(): String = "${parent.getRoute()}/$PATH"
     }
 
+    @Resource(TakeMultipleStock.PATH)
+    data class TakeMultipleStock(
+        val parent: AlmacenItemResource = AlmacenItemResource()
+    ) {
+
+        companion object {
+            const val PATH: String = "take-multiple"
+        }
+
+        fun getRoute(): String = "${parent.getRoute()}/$PATH"
+    }
+
+    @Resource(AddMultipleStock.PATH)
+    data class AddMultipleStock(
+        val parent: AlmacenItemResource = AlmacenItemResource()
+    ) {
+
+        companion object {
+            const val PATH: String = "add-multiple"
+        }
+
+        fun getRoute(): String = "${parent.getRoute()}/$PATH"
+    }
+
     @Resource(Id.PATH)
     data class Id(
         val parent: AlmacenItemResource = AlmacenItemResource(),


### PR DESCRIPTION
- Added new resource classes `TakeMultipleStock` and `AddMultipleStock` to `AlmacenItemResource.kt`.
- These resources are nested under `AlmacenItemResource` and define paths for taking and adding multiple stock items respectively.
- Updated the version of `almacen-service-network-resources` to `1.1.0-SNAPSHOT`.