### PR TITLE
Fix: Update Maven publication to use Kotlin components

### DIFF
--- a/almacen-service-network-model/build.gradle.kts
+++ b/almacen-service-network-model/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("gpr") {
-            from(components["java"])
+            from(components["kotlin"])
         }
     }
 

--- a/almacen-service-network-resources/build.gradle.kts
+++ b/almacen-service-network-resources/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("gpr") {
-            from(components["java"])
+            from(components["kotlin"])
         }
     }
 

--- a/login-service-network-model/build.gradle.kts
+++ b/login-service-network-model/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("gpr") {
-            from(components["java"])
+            from(components["kotlin"])
         }
     }
 

--- a/login-service-network-resources/build.gradle.kts
+++ b/login-service-network-resources/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("gpr") {
-            from(components["java"])
+            from(components["kotlin"])
         }
     }
 

--- a/users-service-network-model/build.gradle.kts
+++ b/users-service-network-model/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("gpr") {
-            from(components["java"])
+            from(components["kotlin"])
         }
     }
 

--- a/users-service-network-resources/build.gradle.kts
+++ b/users-service-network-resources/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 publishing {
     publications {
         create<MavenPublication>("gpr") {
-            from(components["java"])
+            from(components["kotlin"])
         }
     }
 


### PR DESCRIPTION
Changed the `from` component in the `MavenPublication` for GPR from `java` to `kotlin` in the following modules:
- `users-service-network-model`
- `almacen-service-network-resources`
- `users-service-network-resources`
- `login-service-network-model`
- `almacen-service-network-model`
- `login-service-network-resources`