### PR TITLE
Refactor: Make `minimum` field in `AlmacenItemModel` nullable

### DIFF
--- a/almacen-service-network-model/build.gradle.kts
+++ b/almacen-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "1.1.0-SNAPSHOT"
+version = "1.1.1-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenItemModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenItemModel.kt
@@ -13,7 +13,7 @@ data class AlmacenItemModel(
     val quantity: Int,
     @SerialName("pack_size")
     val packSize: Int,
-    val minimum: Int
+    val minimum: Int?
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -38,7 +38,7 @@ data class AlmacenItemModel(
         var result = id.hashCode()
         result = 31 * result + quantity
         result = 31 * result + packSize
-        result = 31 * result + minimum
+        result = 31 * result + (minimum ?: 0)
         result = 31 * result + barcodes.contentHashCode()
         result = 31 * result + name.hashCode()
         result = 31 * result + (supplier?.hashCode() ?: 0)


### PR DESCRIPTION
- Changed the `minimum` field in `AlmacenItemModel` from `Int` to `Int?` to allow for null values.
- Updated the `equals` and `hashCode` methods to correctly handle the nullable `minimum` field.
- Updated `almacen-service-network-model` version to `1.1.1-SNAPSHOT`.