### PR TITLE
feat: Add `AlmacenRecordResource` for record operations

### DIFF
--- a/almacen-service-network-resources/build.gradle.kts
+++ b/almacen-service-network-resources/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "1.1.0-SNAPSHOT"
+version = "1.2.0-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/almacen-service-network-resources/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/resources/AlmacenRecordResource.kt
+++ b/almacen-service-network-resources/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/resources/AlmacenRecordResource.kt
@@ -1,0 +1,84 @@
+package com.cocot3ro.gh.almacen.data.network.resources
+
+import io.ktor.resources.Resource
+
+@Resource(AlmacenRecordResource.PATH)
+class AlmacenRecordResource {
+
+    companion object {
+        const val PATH: String = "/api/almacen/records"
+    }
+
+    @Resource(All.PATH)
+    data class All(
+        val parent: AlmacenRecordResource = AlmacenRecordResource()
+    ) {
+
+        companion object {
+            const val PATH: String = "all"
+        }
+    }
+
+    @Resource(RecordUser.PATH)
+    data class RecordUser(
+        val parent: AlmacenRecordResource = AlmacenRecordResource()
+    ) {
+
+        companion object {
+            const val PATH: String = "user"
+        }
+
+        @Resource(Id.PATH)
+        data class Id(
+            val parent: RecordUser = RecordUser(),
+            val id: Long
+        ) {
+
+            companion object {
+                const val PATH: String = "{id}"
+            }
+        }
+    }
+
+    @Resource(RecordStore.PATH)
+    data class RecordStore(
+        val parent: AlmacenRecordResource = AlmacenRecordResource()
+    ) {
+
+        companion object {
+            const val PATH: String = "store"
+        }
+
+        @Resource(Id.PATH)
+        data class Id(
+            val parent: RecordStore = RecordStore(),
+            val id: Long
+        ) {
+
+            companion object {
+                const val PATH: String = "{id}"
+            }
+        }
+    }
+
+    @Resource(RecordItem.PATH)
+    data class RecordItem(
+        val parent: AlmacenRecordResource = AlmacenRecordResource()
+    ) {
+
+        companion object {
+            const val PATH: String = "item"
+        }
+
+        @Resource(Id.PATH)
+        data class Id(
+            val parent: RecordItem = RecordItem(),
+            val id: Long
+        ) {
+
+            companion object {
+                const val PATH: String = "{id}"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the `AlmacenRecordResource` class, which defines the API endpoints for managing warehouse records.

It includes nested resources for fetching records:
- `All`: Retrieves all records.
- `RecordUser.Id`: Retrieves records by user ID.
- `RecordStore.Id`: Retrieves records by store ID.
- `RecordItem.Id`: Retrieves records by item ID.

The version of `almacen-service-network-resources` has been updated to `1.2.0-SNAPSHOT`.