### PR TITLE
feat: Add Almacen record models

### DIFF
--- a/almacen-service-network-model/build.gradle.kts
+++ b/almacen-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "1.2.0-SNAPSHOT"
+version = "1.3.0-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenItemRecordModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenItemRecordModel.kt
@@ -1,0 +1,9 @@
+package com.cocot3ro.gh.almacen.data.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlmacenItemRecordModel(
+    val id: Long,
+    val name: String
+)

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenRecordModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenRecordModel.kt
@@ -1,0 +1,22 @@
+package com.cocot3ro.gh.almacen.data.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlmacenRecordModel(
+    val id: Long,
+
+    @SerialName("user_id")
+    val userId: Long,
+
+    @SerialName("store_id")
+    val storeId: Long,
+
+    @SerialName("item_id")
+    val itemId: Long,
+
+    val timestamp: String,
+
+    val quantity: Int
+)

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenStoreRecordModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenStoreRecordModel.kt
@@ -1,0 +1,9 @@
+package com.cocot3ro.gh.almacen.data.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlmacenStoreRecordModel(
+    val id: Long,
+    val name: String
+)

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenUserRecordModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenUserRecordModel.kt
@@ -1,0 +1,9 @@
+package com.cocot3ro.gh.almacen.data.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlmacenUserRecordModel(
+    val id: Long,
+    val name: String
+)


### PR DESCRIPTION
Introduced new data models for representing records in the `almacen-service-network-model`:

- `AlmacenItemRecordModel`: Represents an item record with `id` and `name`.
- `AlmacenStoreRecordModel`: Represents a store record with `id` and `name`.
- `AlmacenUserRecordModel`: Represents a user record with `id` and `name`.
- `AlmacenRecordModel`: Represents a general almacén record with `id`, `userId`, `storeId`, `itemId`, `timestamp`, and `quantity`.

Updated the version of `almacen-service-network-model` to `1.3.0-SNAPSHOT`.