### PR TITLE
Refactor: Rename `AlmacenMultipleStockModel` to `AlmacenTakeMultipleS…

### DIFF
--- a/almacen-service-network-model/build.gradle.kts
+++ b/almacen-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "1.3.1-SNAPSHOT"
+version = "1.3.2-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenAddMultipleStockModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenAddMultipleStockModel.kt
@@ -1,11 +1,8 @@
 package com.cocot3ro.gh.almacen.data.network.model
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AlmacenMultipleStockModel(
-    @SerialName("store_id")
-    val storeId: Long,
+data class AlmacenAddMultipleStockModel(
     val map: Map<Long, Int>
 )

--- a/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenTakeMultipleStockModel.kt
+++ b/almacen-service-network-model/src/main/kotlin/com/cocot3ro/gh/almacen/data/network/model/AlmacenTakeMultipleStockModel.kt
@@ -1,0 +1,11 @@
+package com.cocot3ro.gh.almacen.data.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AlmacenTakeMultipleStockModel(
+    @SerialName("store_id")
+    val storeId: Long,
+    val map: Map<Long, Int>
+)


### PR DESCRIPTION
…tockModel`

- Renamed the data class `AlmacenMultipleStockModel` to `AlmacenTakeMultipleStockModel`.
- Added a new data class `AlmacenAddMultipleStockModel` with a `map` property.
- Updated the version of `almacen-service-network-model` to `1.3.2-SNAPSHOT`.