### PR TITLE
Refactor: Rename `breakfast` to `breakfasts` in `HabRecordModel`

### DIFF
--- a/habs-service-network-model/build.gradle.kts
+++ b/habs-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.1-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/habs-service-network-model/src/main/kotlin/com/cocot3ro/gh/services/habs/HabRecordModel.kt
+++ b/habs-service-network-model/src/main/kotlin/com/cocot3ro/gh/services/habs/HabRecordModel.kt
@@ -12,7 +12,7 @@ data class HabRecordModel(
     @SerialName("register_timestamp")
     val registerTimestamp: String,
 
-    val breakfast: Int,
+    val breakfasts: Int,
 
     val lunches: Int,
 


### PR DESCRIPTION
- The field `breakfast` in `HabRecordModel.kt` has been renamed to `breakfasts` for consistency with `lunches` and `dinners`.
- Updated the version of `habs-service-network-model` to `1.0.1-SNAPSHOT`.