### PR TITLE
Update GitHub Actions workflow to specify Xcode version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
           distribution: 'temurin'
           java-version: 21
 
+      - name: Set up Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+
       - name: Configure Gradle
         run: |
           mkdir -p ~/.gradle


### PR DESCRIPTION
The `release.yml` workflow has been updated to explicitly select Xcode version 15.2. This ensures a consistent build environment for iOS targets.