### PR TITLE
Fix: Simplify Gradle publish task in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
           echo "gpr.key=${{ secrets.GITHUB_TOKEN }}" >> ~/.gradle/gradle.properties
 
       - name: Publish module ${{ matrix.module }}
-        run: ./gradlew :${{ matrix.module }}:publishKotlinMultiplatformPublicationToGithubPackagesRepository
+        run: ./gradlew :${{ matrix.module }}:publish


### PR DESCRIPTION
Changed the Gradle task for publishing modules in the `release.yml` workflow from `:publishKotlinMultiplatformPublicationToGithubPackagesRepository` to the simpler `:publish`.