### PR TITLE
Fix: Update namespaces and versions in service modules

### DIFF
--- a/almacen-service-network-model/build.gradle.kts
+++ b/almacen-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.almacen"
+    namespace = "com.cocot3ro.gh.almacen-service-network-model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/almacen-service-network-resources/build.gradle.kts
+++ b/almacen-service-network-resources/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.almacen"
+    namespace = "com.cocot3ro.gh.almacen-service-network-model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/habs-service-network-model/build.gradle.kts
+++ b/habs-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.habs"
+    namespace = "com.cocot3ro.gh.habs-service-network-model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/habs-service-network-resources/build.gradle.kts
+++ b/habs-service-network-resources/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.habs"
+    namespace = "com.cocot3ro.gh.habs-service-network-resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/login-service-network-model/build.gradle.kts
+++ b/login-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.login"
+    namespace = "com.cocot3ro.gh.login-service-network-model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/login-service-network-resources/build.gradle.kts
+++ b/login-service-network-resources/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.login"
+    namespace = "com.cocot3ro.gh.login-service-network-resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/users-service-network-model/build.gradle.kts
+++ b/users-service-network-model/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.users"
+    namespace = "com.cocot3ro.gh.users-service-network-model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/users-service-network-resources/build.gradle.kts
+++ b/users-service-network-resources/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.cocot3ro.gh.deps"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.2-SNAPSHOT"
 
 kotlin {
     jvm()
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.users"
+    namespace = "com.cocot3ro.gh.users-service-network-resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {


### PR DESCRIPTION
Updated the Android namespace and version for the following modules:

- `login-service-network-resources`:
    - Namespace changed from `com.cocot3ro.gh.login` to `com.cocot3ro.gh.login-service-network-resources`
    - Version updated to `2.0.2-SNAPSHOT`
- `habs-service-network-resources`:
    - Namespace changed from `com.cocot3ro.gh.habs` to `com.cocot3ro.gh.habs-service-network-resources`
    - Version updated to `2.0.2-SNAPSHOT`
- `users-service-network-resources`:
    - Namespace changed from `com.cocot3ro.gh.users` to `com.cocot3ro.gh.users-service-network-resources`
    - Version updated to `2.0.2-SNAPSHOT`
- `almacen-service-network-resources`:
    - Namespace changed from `com.cocot3ro.gh.almacen` to `com.cocot3ro.gh.almacen-service-network-model`
    - Version updated to `2.0.2-SNAPSHOT`
- `login-service-network-model`:
    - Namespace changed from `com.cocot3ro.gh.login` to `com.cocot3ro.gh.login-service-network-model`
    - Version updated to `2.0.2-SNAPSHOT`
- `users-service-network-model`:
    - Namespace changed from `com.cocot3ro.gh.users` to `com.cocot3ro.gh.users-service-network-model`
    - Version updated to `2.0.2-SNAPSHOT`
- `habs-service-network-model`:
    - Namespace changed from `com.cocot3ro.gh.habs` to `com.cocot3ro.gh.habs-service-network-model`
    - Version updated to `2.0.2-SNAPSHOT`
- `almacen-service-network-model`:
    - Namespace changed from `com.cocot3ro.gh.almacen` to `com.cocot3ro.gh.almacen-service-network-model`
    - Version updated to `2.0.2-SNAPSHOT`