### PR TITLE
Refactor: Standardize Android namespaces

### DIFF
--- a/almacen-service-network-model/build.gradle.kts
+++ b/almacen-service-network-model/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.almacen-service-network-model"
+    namespace = "com.cocot3ro.gh.almacen.data.network.model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/almacen-service-network-resources/build.gradle.kts
+++ b/almacen-service-network-resources/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.almacen-service-network-model"
+    namespace = "com.cocot3ro.gh.almacen.data.network.resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/habs-service-network-model/build.gradle.kts
+++ b/habs-service-network-model/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.habs-service-network-model"
+    namespace = "com.cocot3ro.gh.habs.data.network.model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/habs-service-network-resources/build.gradle.kts
+++ b/habs-service-network-resources/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.habs-service-network-resources"
+    namespace = "com.cocot3ro.gh.habs.data.network.resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/login-service-network-model/build.gradle.kts
+++ b/login-service-network-model/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.login-service-network-model"
+    namespace = "com.cocot3ro.gh.login.data.network.model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/login-service-network-resources/build.gradle.kts
+++ b/login-service-network-resources/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.login-service-network-resources"
+    namespace = "com.cocot3ro.gh.login.data.network.resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/users-service-network-model/build.gradle.kts
+++ b/users-service-network-model/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.users-service-network-model"
+    namespace = "com.cocot3ro.gh.users.data.network.model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {

--- a/users-service-network-resources/build.gradle.kts
+++ b/users-service-network-resources/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.cocot3ro.gh.users-service-network-resources"
+    namespace = "com.cocot3ro.gh.users.data.network.resources"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {


### PR DESCRIPTION
Updated the Android `namespace` in the `build.gradle.kts` files for the following modules to follow a consistent pattern: `com.cocot3ro.gh.<service_name>.data.network.<model_or_resources>`

- `almacen-service-network-model`: from `com.cocot3ro.gh.almacen-service-network-model` to `com.cocot3ro.gh.almacen.data.network.model`
- `almacen-service-network-resources`: from `com.cocot3ro.gh.almacen-service-network-model` to `com.cocot3ro.gh.almacen.data.network.resources`
- `habs-service-network-model`: from `com.cocot3ro.gh.habs-service-network-model` to `com.cocot3ro.gh.habs.data.network.model`
- `habs-service-network-resources`: from `com.cocot3ro.gh.habs-service-network-resources` to `com.cocot3ro.gh.habs.data.network.resources`
- `login-service-network-model`: from `com.cocot3ro.gh.login-service-network-model` to `com.cocot3ro.gh.login.data.network.model`
- `login-service-network-resources`: from `com.cocot3ro.gh.login-service-network-resources` to `com.cocot3ro.gh.login.data.network.resources`
- `users-service-network-model`: from `com.cocot3ro.gh.users-service-network-model` to `com.cocot3ro.gh.users.data.network.model`
- `users-service-network-resources`: from `com.cocot3ro.gh.users-service-network-resources` to `com.cocot3ro.gh.users.data.network.resources`